### PR TITLE
fix: corrected a spelling mistake in Stories

### DIFF
--- a/stories/buttons/filter-button.stories.tsx
+++ b/stories/buttons/filter-button.stories.tsx
@@ -12,19 +12,19 @@ const meta: Meta<typeof FilterButton> = {
 			control: { type: 'boolean' },
 		},
 		onClick: {
-			table: { disable: true }
+			table: { disable: true },
 		},
 		icon: {
-			table: { disable: true }
+			table: { disable: true },
 		},
-	}
+	},
 };
 
 export default meta;
 
 type Story = StoryObj<typeof FilterButton>;
 
-export const standart: Story = {
+export const standard: Story = {
 	args: {
 		text: 'Click me!',
 		icon: <TfiUser size={18} />,

--- a/stories/buttons/option-button.stories.tsx
+++ b/stories/buttons/option-button.stories.tsx
@@ -24,7 +24,7 @@ export default meta;
 
 type Story = StoryObj<typeof OptionButton>;
 
-export const standart: Story = {
+export const standard: Story = {
 	args: {
 		text: 'Click me!',
 		icon: <TfiUser size={18} />,

--- a/stories/inputs/input.stories.tsx
+++ b/stories/inputs/input.stories.tsx
@@ -9,30 +9,35 @@ const meta: Meta<typeof Input> = {
 	component: Input,
 	argTypes: {
 		icon: {
-			table: { disable: true }
+			table: { disable: true },
 		},
 		required: {
-			table: { disable: true }
+			table: { disable: true },
 		},
 		type: {
-			options: ['text', 'email', 'number', 'password'],
+			options: [
+				'text',
+				'email',
+				'number',
+				'password',
+			],
 			control: {
-				type: 'select'
-			}
+				type: 'select',
+			},
 		},
 		disabled: {
 			control: {
-				type: 'boolean'
-			}
-		}
-	}
+				type: 'boolean',
+			},
+		},
+	},
 };
 
 export default meta;
 
 type Story = StoryObj<typeof Input>;
 
-export const standart: Story = {
+export const standard: Story = {
 	args: {
 		icon: <TfiUser size={18} />,
 		showError: false,

--- a/stories/inputs/search-input.stories.tsx
+++ b/stories/inputs/search-input.stories.tsx
@@ -7,27 +7,27 @@ const meta: Meta<typeof SearchInput> = {
 	component: SearchInput,
 	argTypes: {
 		icon: {
-			table: { disable: true }
+			table: { disable: true },
 		},
 		required: {
-			table: { disable: true }
+			table: { disable: true },
 		},
 		type: {
-			table: { disable: true }
+			table: { disable: true },
 		},
 		disabled: {
 			control: {
-				type: 'boolean'
-			}
-		}
-	}
+				type: 'boolean',
+			},
+		},
+	},
 };
 
 export default meta;
 
 type Story = StoryObj<typeof SearchInput>;
 
-export const standart: Story = {
+export const standard: Story = {
 	args: {
 		showError: false,
 		errorMessage: '',


### PR DESCRIPTION
A spelling correction in the Stories of a few components. Their default variant were called **"standart"** instead of **"standard"**