### PR TITLE
Refactor: lecture card duration display

### DIFF
--- a/src/components/lecture-card/index.tsx
+++ b/src/components/lecture-card/index.tsx
@@ -26,7 +26,7 @@ export const LectureCard = ({
 	name,
 	thumbnail,
 	teacher,
-	duration,
+	durationInSeconds,
 	avaliable,
 	avaliableMessage,
 	finished,
@@ -121,7 +121,9 @@ export const LectureCard = ({
 									<TfiTime size={14} />
 									<Typography
 										variant="paragraph-regular"
-										text={duration}
+										text={secondsToFriendlyString(
+											durationInSeconds
+										)}
 									/>
 								</s.LectureDuration>
 							</s.LectureFineDetails>

--- a/src/components/lecture-card/index.tsx
+++ b/src/components/lecture-card/index.tsx
@@ -60,9 +60,6 @@ export const LectureCard = ({
 		}
 	}
 
-	const formattedClassDuration =
-		secondsToFriendlyString(duration);
-
 	const lectureTypeIcon = determineLectureTypeIcon();
 
 	return (
@@ -124,9 +121,7 @@ export const LectureCard = ({
 									<TfiTime size={14} />
 									<Typography
 										variant="paragraph-regular"
-										text={
-											formattedClassDuration
-										}
+										text={duration}
 									/>
 								</s.LectureDuration>
 							</s.LectureFineDetails>

--- a/src/components/lecture-card/types.ts
+++ b/src/components/lecture-card/types.ts
@@ -8,6 +8,7 @@ export interface LectureCardProps {
 	thumbnail: string;
 	teacher: string;
 	duration: string;
+	durationInSeconds: number;
 	finished?: boolean;
 	onClick: () => void;
 	avaliable: boolean;

--- a/src/components/lecture-card/types.ts
+++ b/src/components/lecture-card/types.ts
@@ -7,7 +7,7 @@ export interface LectureCardProps {
 	name: string;
 	thumbnail: string;
 	teacher: string;
-	duration: number;
+	duration: string;
 	finished?: boolean;
 	onClick: () => void;
 	avaliable: boolean;


### PR DESCRIPTION
This PR includes:
* A change to the value used for _duration_ in the `LectureCard` component, going from `duration` to `durationInSeconds`